### PR TITLE
make action more robust; mvnd v1.0.2; .tar.gz archive; download speedup (GitHub mirror)

### DIFF
--- a/.github/actions/install-mvnd/action.yaml
+++ b/.github/actions/install-mvnd/action.yaml
@@ -47,18 +47,29 @@ runs:
           --show-error \
           --location \
           --fail-with-body \
-          --output mvnd.zip \
-          "https://github.com/apache/maven-mvnd/releases/download/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}.zip"
+          --output mvnd.tar.gz \
+          "https://github.com/apache/maven-mvnd/releases/download/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}.tar.gz"
       if: inputs.dry-run == 'false'
       shell: bash
-    - run: curl -fsSL -o mvnd.zip.sha256 https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}.zip.sha256
+    - run: |
+        curl \
+          --connect-timeout 5 \
+          --retry 5 \
+          --retry-delay 1 \
+          --retry-max-time 40 \
+          --silent \
+          --show-error \
+          --location \
+          --fail-with-body \
+          --output mvnd.tar.gz.sha256 \
+          "https://github.com/apache/maven-mvnd/releases/download/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}.tar.gz.sha256"
       if: inputs.dry-run == 'false'
       shell: bash
     - id: integrity-check
-      run: echo "$(cat mvnd.zip.sha256) mvnd.zip" | sha256sum --check
+      run: echo "$(cat mvnd.tar.gz.sha256) mvnd.tar.gz" | sha256sum --check
       if: inputs.dry-run == 'false'
       shell: bash
-    - run: unzip mvnd.zip -d /tmp/
+    - run: tar xvf mvnd.tar.gz -C /tmp/
       if: inputs.dry-run == 'false'
       shell: bash
     - id: mvnd-location

--- a/.github/actions/install-mvnd/action.yaml
+++ b/.github/actions/install-mvnd/action.yaml
@@ -37,7 +37,18 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: curl -fsSL -o mvnd.zip https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}.zip
+    - run: |
+        curl \
+          --connect-timeout 5 \
+          --retry 5 \
+          --retry-delay 1 \
+          --retry-max-time 40 \
+          --silent \
+          --show-error \
+          --location \
+          --fail-with-body \
+          --output mvnd.zip \
+          "https://github.com/apache/maven-mvnd/releases/download/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}.zip"
       if: inputs.dry-run == 'false'
       shell: bash
     - run: curl -fsSL -o mvnd.zip.sha256 https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}.zip.sha256

--- a/.github/actions/install-mvnd/action.yaml
+++ b/.github/actions/install-mvnd/action.yaml
@@ -21,11 +21,11 @@ inputs:
   version:
     description: 'The version of the Maven Daemon to install'
     required: true
-    default: '1.0-m6'
+    default: '1.0.2'
   distribution:
     description: 'The Maven distribution to use'
     required: true
-    default: 'm39-linux-amd64'
+    default: 'linux-amd64'
   dry-run:
     description: 'Flag to enable to the dry-run mode'
     required: true


### PR DESCRIPTION
curl took a very long time to execute in #27 -- GitHub network is sometimes unreliable and sluggish.

* expand existing options to long options for better readability
* add options for timeouts, better error handling, retry (aka batch mode)
* use github.com download URL for significantly better download times
* Update to v1.0.2


This difference is just the URL download root change:

![image](https://github.com/user-attachments/assets/6ca9867a-bcc3-4273-a79b-6383dfa88f47)
